### PR TITLE
Readme fix

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -64,6 +64,9 @@ devtools::install_github("Appsilon/`r params$repo_name`", ref = "0.1.0")
 
 Example {.firebrick}
 -------
+
+Before running an example make sure that your RethinkDB is set-up and running. For installation and running guidelines you can visit [RethinkDB docs](https://www.rethinkdb.com/).
+
 ```
 library(shiny)
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ To install [previous version]() you can run:
 Example
 -------
 
+Before running an example make sure that your RethinkDB is set-up and running. For installation and running guidelines you can visit [RethinkDB docs](https://www.rethinkdb.com/).
+
     library(shiny)
 
     ui <- shinyUI(fluidPage(


### PR DESCRIPTION
Added a piece of text describing that `RethinkDB` must be running before trying an example. Before it caused some confusion, look: #6 and #3 .